### PR TITLE
Add initial tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2.1
+
+orbs:
+  kaocha: lambdaisland/kaocha@0.0.3
+  clojure: lambdaisland/clojure@0.0.8
+
+jobs:
+  test:
+    parameters:
+      os:
+        type: executor
+      clojure_version:
+        type: string
+    executor: << parameters.os >>
+    steps:
+      - checkout
+      - clojure/with_cache:
+          cache_version: << parameters.clojure_version >>
+          steps:
+            - run: clojure -e '(println (System/getProperty "java.runtime.name") (System/getProperty "java.runtime.version") "\nClojure" (clojure-version))'
+            - kaocha/execute:
+                args: "unit --reporter documentation --plugin cloverage --codecov"
+                clojure_version: << parameters.clojure_version >>
+            - kaocha/upload_codecov:
+                flags: unit
+
+workflows:
+  kaocha_test:
+    jobs:
+      - test:
+          matrix:
+            parameters:
+              os: [clojure/openjdk17, clojure/openjdk11, clojure/openjdk8]
+              clojure_version: ["1.9.0", "1.10.3", "1.11.1"]

--- a/deps.edn
+++ b/deps.edn
@@ -10,4 +10,4 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha {"1.80.1274"}}}}}
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.80.1274"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -10,4 +10,4 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha {:local/root "../kaocha" #_#_:mvn/version "1.78.1249"}}}}}
+   :extra-deps  {lambdaisland/kaocha {"1.80.1274"}}}}}

--- a/test/kaocha/type/doctest_test.clj
+++ b/test/kaocha/type/doctest_test.clj
@@ -1,0 +1,33 @@
+
+(ns kaocha.type.doctest-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [kaocha.type.doctest :as doctest]))
+
+(deftest test-doctest-parsing
+  (testing "simple forms are extracted"
+    (is (= (doctest/extract-doctests
+             "some docstring
+             (+ 1 1)
+             ;; => 2")
+           [['(+ 1 1) 2]])))
+  (testing "nested forms are extracted"
+    (is (= (doctest/extract-doctests 
+             "some docstring
+             (+ (* 2 2) 1)
+             ;; => 5")
+           [['(+ (* 2 2) 1) 5]])))
+  (testing "forms with data structure literals are extracted"
+    (is (= (doctest/extract-doctests 
+             "some docstring
+             (map inc [1 2 3])
+             ;; => (2 3 4)") 
+           [['(map inc [1 2 3]) '(2 3 4)]])))
+  (testing "parentheticals as a part of ordinary prose text are not extracted"
+    (is (= (doctest/extract-doctests
+             "some forms, like (map inc [1 2 3]), include functions as function arguments.
+             (2 3 4)")
+           [])))
+  (testing "'arrows' ('=>') as a part of ordinary prose text are not extracted"
+    (is (= (doctest/extract-doctests
+             "foo => bar")
+           []))))

--- a/tests.edn
+++ b/tests.edn
@@ -2,5 +2,6 @@
 {:tests   [{:id          :doctests
             :type        :kaocha.type/doctest
             :test-paths  ["src"]
-            :ns-patterns [".*"]}]
+            :ns-patterns [".*"]}
+           {:id          :unit }]
  :reporter [kaocha.report/documentation]}


### PR DESCRIPTION
We don't want to lock in our API or anything at this point, but we are less likely to change the format of the tests themselves during this early period and we don't want to break by accident.
